### PR TITLE
Update kavie.js

### DIFF
--- a/dist/kavie.js
+++ b/dist/kavie.js
@@ -93,6 +93,14 @@
     parentSection.children[childSectionName] = new KavieSection();
   }
 
+  ns.resetValidation = function(vm){
+    var kavieObservables = compileObservables(vm);
+
+    for(var i = 0; i < kavieObservables.length; i ++){
+      kavieObservables[i].resetErrorMessages();
+    }
+  }
+
   var isKavieObservable = function(observable){
     return observable.hasOwnProperty("hasError");
   }
@@ -316,6 +324,11 @@ ko.extenders.kavie = function (target, rules){
       if (target.subscription){
         target.subscription.dispose();
       }
+      target.hasError(false);
+      target.errorMessage("");
+    }
+    
+    target.resetErrorMessages = function(){
       target.hasError(false);
       target.errorMessage("");
     }


### PR DESCRIPTION
Hi please view my changes..
There's a new validation method call 'resetValidation()' which reset all the error messages.
This is useful when you want to create a new record that is re-populated with no data (the default is empty) but you have all the validation errors from the previous record.
So basically before you show the form (or after you leave the form) you put the following line to reset all error messages:
´Kavie.resetValidation(self);´

Cheers!